### PR TITLE
#235: updated navigation bar background to dark blue

### DIFF
--- a/BNote/style/css/ids.css
+++ b/BNote/style/css/ids.css
@@ -129,7 +129,7 @@ background-color: #fff;
 #optionsbar {
 	height: 40px;
 	border-bottom: 1px solid #dcdcdc;
-	background-color: #444444;
+	background-color: #436f98;
 	padding-top: 10px;
 }
 


### PR DESCRIPTION
Alternatives Design für die Navigation Bar
<img width="1579" alt="screen shot 2017-03-23 at 20 07 05" src="https://cloud.githubusercontent.com/assets/2054402/24265618/6eb97c40-1004-11e7-814c-f1a7236f43eb.png">
