### PR TITLE
Alphabetically ordered drop down list

### DIFF
--- a/BNote/src/presentation/modules/repertoireview.php
+++ b/BNote/src/presentation/modules/repertoireview.php
@@ -273,6 +273,7 @@ class RepertoireView extends CrudRefView {
 			foreach($possibleFiles as $i => $fileinfo) {
 				$dd->addOption($fileinfo["filename"], $fileinfo["fullpath"]);
 			}
+			$dd->sortOptions();
 			$form->addElement("", $dd);
 			$form->write();
 			?>

--- a/BNote/src/presentation/widgets/dropdown.php
+++ b/BNote/src/presentation/widgets/dropdown.php
@@ -22,6 +22,10 @@ class Dropdown implements iWriteable {
 		$this->options[$label] = $value;
 	}
 	
+	public function sortOptions() {
+		ksort($this->options);
+	}
+
 	public function cleanOptions() {
 		$this->options = array();
 	}


### PR DESCRIPTION
Available files in repertoire view dropdown list are ordered alphabetically

When more than just a few files are in the share folder, attaching files to a song in the repertoire becomes very tedious. The user has to scroll and read most of the list, because the files are not ordered. This fix improves the usability a lot by sorting the files alphabetically.

Signed-off-by: Dennis Noppeney <info@dennis-noppeney.de>