### PR TITLE
Fixed type detection for files in share folder with more than one '.'…

### DIFF
--- a/BNote/src/presentation/widgets/filebrowser.php
+++ b/BNote/src/presentation/widgets/filebrowser.php
@@ -566,8 +566,8 @@ class Filebrowser implements iWriteable {
 	}
 	
 	private function getFiletype($file) {
-		if(strpos($file, ".") !== false) {
-			$end = strtolower(substr($file, strpos($file, ".")+1));
+		if(strrpos($file, ".") !== false) {
+			$end = strtolower(substr($file, strrpos($file, ".")+1));
 			$music = array("mp3", "ogg", "acc", "wav");
 			if(in_array($end, $music)) {
 				return "music";


### PR DESCRIPTION
… in file name.

The existing file type detection searched for the first dot in file name to extract the file extension. This does not work if the filename contains multiple dots e.g. "MySong.Tenor.mp3".
This issue was fixed by searched for the first dot from the end of the filename.