### PR TITLE
Fixed growing zip archives

### DIFF
--- a/BNote/src/presentation/widgets/filebrowser.php
+++ b/BNote/src/presentation/widgets/filebrowser.php
@@ -657,7 +657,7 @@ class Filebrowser implements iWriteable {
 		
 		// initialize zip-archive
 		$zip = new ZipArchive();
-		$zip->open($zip_fname, ZipArchive::CREATE);
+		$zip->open($zip_fname, ZipArchive::OVERWRITE);
 		$dir_basepath = $this->root . $this->path;
 		$dir_basepath = str_replace("\\", "/", $dir_basepath);
 		


### PR DESCRIPTION
When a zip archive is created from a shared folder shortly after another zip archive has been created, the new archive contains the selected files and also the files selected for the previous zip archive. This behaviour makes zip archives grow larger and larger with every request.

The reason seems to be the ZipArchive::CREATE option, which only creates a new archive if  it does not exist. If the archive exists, the exist it is not deleted. The option ZipArchive::OVERWRITE seems more suitable.