### PR TITLE
Filebrowser does not preload audio files

### DIFF
--- a/BNote/src/presentation/widgets/filebrowser.php
+++ b/BNote/src/presentation/widgets/filebrowser.php
@@ -320,7 +320,7 @@ class Filebrowser implements iWriteable {
 						else {
 							$audioType = $mime;
 						}
-						echo '<audio controls style="display: block;">';
+						echo '<audio controls style="display: block;" preload="none">';
 						echo ' <source src="' . $link . '" type="audio/' . $audioType . '">';
 						echo 'Unsupported media type</audio>';
 					}


### PR DESCRIPTION
When a share folder contains multiple audio files at least some browsers load all of them right from the beginning. This can cause a heavy traffic which is usually unnecessary. I also observed that loading got stuck and some audio files could not be played. The user had to abort loading and re-load.

This fix tells the browser not to load the audio files on startup. Now audio files are only loaded on demand from the server. It seems that now the problem described above is gone.

Signed-off-by: Dennis Noppeney <info@dennis-noppeney.de>