### PR TITLE
Fixed zip download of Share Folders

### DIFF
--- a/BNote/src/presentation/widgets/filebrowser.php
+++ b/BNote/src/presentation/widgets/filebrowser.php
@@ -681,7 +681,7 @@ class Filebrowser implements iWriteable {
 		
 		// initialize zip-archive
 		$zip = new ZipArchive();
-		$zip->open($zip_fname, ZipArchive::OVERWRITE);
+		$zip->open($zip_fname, ZipArchive::CREATE | ZipArchive::OVERWRITE);
 		$dir_basepath = $this->root . $this->path;
 		$dir_basepath = str_replace("\\", "/", $dir_basepath);
 		


### PR DESCRIPTION
The fix cf8107e3 from November 2019 fixed the unexpected big zip archives due to unintended appending of new content to old archives. Now it turned out that the fix only worked, if there is still a temporary zip folder present that can be overwritten. If that file is not present, creating of a new zip archive failed.

This commit fixes this, by combining the CREATE and the OVERWRITE flag.