### PR TITLE
Enabled Rewrite module in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,4 @@
 FROM php:7.1.2-apache 
 RUN docker-php-ext-install mysqli
+RUN a2enmod rewrite
+


### PR DESCRIPTION
The docker container did not support the Bnote app, because the .htaccess file in the export API folder contains rewrite rules, but in the Docker container the Apache rewrite module is not enabled.
This fix enables the rewrite module.

Signed-off-by: Dennis Noppeney <info@dennis-noppeney.de>