### PR TITLE
Fixed download of zipped folders from share module

### DIFF
--- a/BNote/src/data/filehandler.php
+++ b/BNote/src/data/filehandler.php
@@ -11,23 +11,23 @@ class FileHandler {
 
 	private $innerpath;
 	private $filepath;
-	
+
 	/**
 	 * Relative path to root directory.
 	 */
 	private $dir_prefix = "../../";
-	
+
 	function __construct() {
-		if(!isset($_GET["mode"])) {	
+		if(!isset($_GET["mode"])) {
 			if(!isset($GLOBALS["DATA_PATHS"]["share"])) echo "Filesystem configuration missing";
 		}
-		
+
 		$this->init();
 		if($this->authorize()) {
 			$this->giveFile();
 		}
 	}
-	
+
 	private function init() {
 		if(!isset($_GET["file"])) exit;
 		if(isset($_GET["mode"])) {
@@ -38,71 +38,72 @@ class FileHandler {
 		}
 		$this->filepath = $this->dir_prefix . $this->innerpath;
 		$this->filepath = str_replace("\\'", "'", $this->filepath);
+		$this->filepath = realpath($this->filepath);
 		
 		if(!file_exists($this->filepath)) {
 			header("HTTP/1.0 404 " . $this->innerpath . " not found");
 			exit;
 		}
-		
+
 		if(!is_file($this->filepath)) {
 			header("HTTP/1.0 405 Only files are supported.");
 			exit;
 		}
 	}
-	
+
 	private function authorize() {
 		session_start();
 		if(!isset($_SESSION["user"])) {
 			header('HTTP/1.0 403 Forbidden');
-			echo "No access to file.";			
+			echo "No access to file.";
 			return false;
 		}
-		else {			
+		else {
 			// connect to application
 			require_once("systemdata.php");
 			$GLOBALS["DIR_WIDGETS"] = $this->dir_prefix . $GLOBALS["DIR_WIDGETS"];
 			require_once($GLOBALS["DIR_WIDGETS"] . "error.php");
 			$GLOBALS["DIR_LOGIC"] = $this->dir_prefix . $GLOBALS["DIR_LOGIC"];
 			require_once("applicationdataprovider.php");
-			
+
 			// Build Database Connection
 			$db = new Database();
 			$sysdata = new Systemdata($this->dir_prefix);
 			$adp = new ApplicationDataProvider($db, new Regex(), $sysdata);
 			$secManager = $adp->getSecurityManager();
-			
+
 			if(isset($_GET["mode"])) {
 				return $secManager->modeAccess($this->innerpath, $_GET["mode"]);
 			}
-			
+
 			return ($secManager->canUserAccessFile($this->innerpath));
 		}
 	}
-	
+
 	private function getGroupIdFromPath() {
 		$idstart = strpos($this->innerpath, "/group_")+7;
 		$len = strpos($this->innerpath, "/", $idstart) - $idstart;
 		return substr($this->innerpath, $idstart, $len);
 	}
-	
-	private function giveFile() {		
+
+	private function giveFile() {
 		// open the file in a binary mode
 		$fp = fopen($this->filepath, 'rb');
-		
+
 		// send the right headers
 		$type = FileHandler::getFileMimeType($this->filepath);
-		
+
 		header("Content-Type: $type");
-        // forces direct download of media files instead of displaying them in the browser
-        header("Content-Disposition: attachment; filename=\"" . basename($this->innerpath) . "\";");
-        
+		// forces direct download of media files instead of displaying them in the browser
+		header("Content-Disposition: attachment; filename=\"" . basename($this->innerpath) . "\";");
+
 		header("Content-Length: " . filesize($this->filepath));
-		
+
 		// dump the picture and stop the script
 		fpassthru($fp);
 		exit;
 	}
-	
+
 	public static function getFileMimeType($file) {
 		require_once 'abstractfile.php';
 		return getFileMimeType($file);

--- a/BNote/src/presentation/widgets/filebrowser.php
+++ b/BNote/src/presentation/widgets/filebrowser.php
@@ -745,12 +745,12 @@ STRING_END;
 		 * for multi-user access, but there is no or a very complicated cleanup -
 		 * thus this very simple solution.
 		 */
-		$zip_suffix = "_temp/download.zip";
-		$zip_fname = $this->root . $zip_suffix;
+		$temp_dir = $this->root . "_temp";
+		$zip_fname = $temp_dir . "/download.zip";
 
 		// check that _temp folder exists
-		if(!is_dir($this->root . "_temp")) {
-			mkdir($this->root . "_temp");
+		if(!is_dir($temp_dir)) {
+			mkdir($temp_dir);
 		}
 
 		// initialize zip-archive
@@ -775,13 +775,16 @@ STRING_END;
 
 		Writing::p(Lang::txt("Filebrowser_download.archiveCreated"));
 
-		$link = new Link($this->sysdata->getFileHandler() . "?file=" . $zip_suffix, Lang::txt("Filebrowser_download.downloadArchive"));
+		$link = new Link($this->sysdata->getFileHandler() . "?mode=all&file=" .
+		                 urlencode($zip_fname),
+		                 Lang::txt("Filebrowser_download.downloadArchive"));
 		$link->setTarget("_blank");
 		$link->addIcon("arrow_down");
 		$link->write();
 		AbstractView::buttonSpace();
 
-		$back = new Link($this->linkprefix("view&path=" . urlencode($this->path)), Lang::txt("Filebrowser_download.back"));
+		$back = new Link($this->linkprefix("view&path=" . urlencode($this->path)),
+		                 Lang::txt("Filebrowser_download.back"));
 		$back->addIcon("arrow_left");
 		$back->write();
 	}

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,3 +15,6 @@ RUN a2enmod rewrite
 RUN apt-get update -y && apt-get install -y libpng-dev libjpeg-dev
 RUN docker-php-ext-configure gd --with-jpeg
 RUN docker-php-ext-install gd
+
+# The PHP module zip is required for downloading share folders.
+RUN docker-php-ext-install zip


### PR DESCRIPTION
During my work on the picture preview in filebrowser widget, I broke the zip download.

I did some cleanup and aligned all URL file arguments to start with a leading / refering to data/share. Unfortunately the temporary zip file is put into share_temp, and for the zip download the URL file argument starts with _temp. Due to the leading slash this does not work any more.

The issue was fixed to use mode=all for zip file download and specify full path instead of relative path to data/share.