### PR TITLE
Reworked mailing to fix spam problems

### DIFF
--- a/BNote/src/export/BNoteApiImpl.php
+++ b/BNote/src/export/BNoteApiImpl.php
@@ -834,14 +834,9 @@ class BNoteApiImpl implements BNoteApiInterface {
 			new BNoteError(Lang::txt("AbstractBNA_sendMail.error"));
 		}
 		
-		// Receipient Setup
-		$ci = $this->sysdata->getCompanyInformation();
-		$receipient = $ci["Mail"];
-		
-		$mail = new Mailing($receipient, $subject, "");
+		$mail = new Mailing($subject, "");
 		$mail->setBodyInHtml($body);
-		$userContact = $this->sysdata->getUsersContact($this->uid);
-		$mail->setFrom($userContact["email"]);
+		$mail->setFromUser($this->uid);
 		$mail->setBcc($addresses);
 		
 		if(!$mail->sendMail()) {

--- a/BNote/src/export/notify.php
+++ b/BNote/src/export/notify.php
@@ -73,12 +73,6 @@ class Notifier {
 		return $system_data->dbcon->flattenSelection($addressesDbSel, "email");
 	}
 	
-	private function getEnsembleEmail() {
-		global $system_data;
-		$ensemble = $system_data->getCompanyInformation();
-		return $ensemble['Mail'];
-	}
-	
 	private function sendEmailToContacts($contacts, $subject, $body) {
 		// no email must be sent, all good
 		if(count($contacts) == 0) {
@@ -86,7 +80,7 @@ class Notifier {
 		}
 		global $dir_prefix;
 		require_once($dir_prefix . $GLOBALS["DIR_LOGIC"] . "mailing.php");
-		$mail = new Mailing(null, $subject, null);
+		$mail = new Mailing($subject, null);
 		$mail->setBcc($this->getMailAddresses($contacts));  // string of addresses separated properly
 		$mail->setBodyInHtml($body);
 		return $mail->sendMail();

--- a/BNote/src/logic/modules/aufgabencontroller.php
+++ b/BNote/src/logic/modules/aufgabencontroller.php
@@ -32,7 +32,8 @@ class AufgabenController extends DefaultController {
 		}
 		
 		require_once($GLOBALS["DIR_LOGIC"] . "mailing.php");
-		$mail = new Mailing($to, $subject, $body);
+		$mail = new Mailing($subject, $body);
+		$mail->setTo($to);
 		$mail->sendMailWithFailError();
 	}
 }

--- a/BNote/src/logic/modules/kommunikationcontroller.php
+++ b/BNote/src/logic/modules/kommunikationcontroller.php
@@ -141,15 +141,11 @@ class KommunikationController extends DefaultController {
 			new BNoteError(Lang::txt("KommunikationController_sendMail.error"));
 		}
 		
-		// Receipient Setup
 		global $system_data;
-		$ci = $system_data->getCompanyInformation();
-		$receipient = $ci["Mail"];
-		
 		require_once($GLOBALS["DIR_LOGIC"] . "mailing.php");
-		$mail = new Mailing($receipient, $subject, "");
+		$mail = new Mailing($subject, "");
 		$mail->setBodyInHtml($body);
-		$mail->setFrom($this->getData()->getUsermail());
+		$mail->setFromUser($system_data->getUserId());
 		
 		// place receiver addresses into the bcc field
 		$mail->setBcc($addresses);

--- a/BNote/src/logic/modules/kontaktecontroller.php
+++ b/BNote/src/logic/modules/kontaktecontroller.php
@@ -97,10 +97,9 @@ class KontakteController extends DefaultController {
 			
 			// notify user about result
 			require_once($GLOBALS["DIR_LOGIC"] . "mailing.php");
-			$mail = new Mailing($contact["email"], $subject, $body);
-			$bandInfo = $this->getData()->getSysdata()->getCompanyInformation();
-			$mail->setFrom($bandInfo["Mail"]);
-				
+			$mail = new Mailing($subject, $body);
+			$mail->setTo($contact["email"]);
+			
 			if(!$mail->sendMail()) {
 				$this->getView()->userCredentials($username , $password);
 			}

--- a/BNote/src/logic/modules/logincontroller.php
+++ b/BNote/src/logic/modules/logincontroller.php
@@ -140,13 +140,14 @@ class LoginController extends DefaultController {
 		
 		// only change password if mail was sent
 		require_once($GLOBALS["DIR_LOGIC"] . "mailing.php");
-		$mail = new Mailing($_POST["email"], $subject, $body);
+		$mail = new Mailing($subject, $body);
+		$mail->setTo($_POST["email"]);
 		
 		if(!$mail->sendMail()) {
 			// talk to leader
 			new BNoteError(Lang::txt("LoginController_pwForgot.sendMailerror"));
 		}
-		else {					
+		else {
 			// Change password in system only if mail has been sent.
 			$pwenc = crypt($password, LoginController::ENCRYPTION_HASH);
 			$this->getData()->saveNewPassword($uid, $pwenc);
@@ -224,7 +225,8 @@ class LoginController extends DefaultController {
 				$dir_prefix = $GLOBALS['dir_prefix'];
 			}
 			require_once($dir_prefix . $GLOBALS["DIR_LOGIC"] . "mailing.php");
-			$mail = new Mailing($_POST["email"], $subject, $message);
+			$mail = new Mailing($subject, $message);
+			$mail->setTo($_POST["email"]);
 			
 			if(!$mail->sendMail()) {
 				$mailMessage = Lang::txt("LoginController_register.message_3");

--- a/BNote/src/logic/modules/startcontroller.php
+++ b/BNote/src/logic/modules/startcontroller.php
@@ -81,7 +81,7 @@ class StartController extends DefaultController {
 		
 		// send only one email to notify all users
 		require_once($GLOBALS["DIR_LOGIC"] . "mailing.php");
-		$mail = new Mailing(null, $subject, null);
+		$mail = new Mailing($subject, null);
 		$mail->setBodyInHtml($body);
 		$mail->setFromUser($uid);
 		$mail->setBcc($bcc);

--- a/BNote/src/logic/modules/usercontroller.php
+++ b/BNote/src/logic/modules/usercontroller.php
@@ -29,7 +29,8 @@ class UserController extends DefaultController {
 			
 			// send mail
 			require_once($GLOBALS["DIR_LOGIC"] . "mailing.php");
-			$mail = new Mailing($to, $subject, $body);
+			$mail = new Mailing($subject, $body);
+			$mail->setTo($to);
 			
 			if(!$mail->sendMail()) {
 				new Message(Lang::txt("UserController_activate.message_6"), Lang::txt("UserController_activate.message_7"));


### PR DESCRIPTION
When a user sends a message, or comments something on the start page, BNote sent emails and used the commenting user's email address as "from" field. It turned out that this triggered spam filters of some mail providers. Especially Google Mail has become very strict when it comes to spam rejection.

Meanwhile, Google does not accept emails at all from domains without either SPF or DKIM. These means of spam protection are in conflict with BNote's way of sending email because it fakes the sender address. If a user's email domain has an SPF record in DNS, only servers listed in that SPF record are allowed to send emails for that domain. The server, BNote is running on, is usually not in that list, and so emails from BNote are rejected as SPAM.

To overcome this problem the BNote mailing class the following changes have been applied to BNote Mailing:
- The email address from company.xml is always used in "FROM" field.
- If the email was triggered by a user, ...
  - ... the user's name appears in the form "FirstName LastName via Bnote".
  - ... the user's email address is added as "REPLY TO" field, so receipients can simply click "Reply" in their email client.
  - ... the user's email address is also used as "TO" field, to not leave that field empty.

The constructor of the mailing class has been simplified and the argument $to has been removed, because it turned out that this field was often set to null. Now the constructor has just two arguments and the function setTo must be used.

The function getEnsembleEmail in notify.php was removed, because that function was not used anywhere.