### PR TITLE
fix database query for getting reheasal data

### DIFF
--- a/BNote/src/data/modules/startdata.php
+++ b/BNote/src/data/modules/startdata.php
@@ -269,7 +269,7 @@ class StartData extends AbstractLocationData {
 	}
 	
 	function getRehearsal($rid) {
-		$query = "SELECT *, r.notes FROM rehearsal r 
+		$query = "SELECT r.*, l.name, a.street, a.city, a.zip, a.state, a.country FROM rehearsal r 
 					JOIN location l ON r.location = l.id
 					JOIN address a ON l.address = a.id 
 				   WHERE r.id = ?";


### PR DESCRIPTION
Avoid "select *" queries as they are not recommended. The explicit listing of selected fields fixes a bug where 3 database tables are JOINed and all of them contain a field "id". The resulting table has only one field "id" and it seems that its value (depending on the used SQL version and/or randomness) contains the "id" value of one of those three tables. If not the "id" field of the "rehearsal" table is used, then the returned table is incorrectly parsed and the rehearsal information on the start-page are missing some details (such as Ort/Conductor/Repertoire).